### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -55,7 +55,7 @@ function fish_prompt
 
   prompt_root
   prompt_dir
-  available git; and prompt_git
+  type -q git; and prompt_git
   prompt_arrow
 
   set_color normal


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
