### PR TITLE
Make bracket characters customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The glyphs used in the default links can be customized using global variables. H
 - `$chain_git_branch_glyph`: Glyph to indicate the Git branch.
 - `$chain_git_dirty_glyph`: Glyph to indicate that the working branch has uncommitted changes.
 - `$chain_su_glyph`: Glyph to indicate that you have superuser privileges.
+- `$chain_link_open_glyph`: Glyph before each individual chain link (default `<`).
+- `$chain_link_close_glyph`: Glyph after each individual chain link (default `>`).
 
 
 ## License

--- a/functions/chain.compile.fish
+++ b/functions/chain.compile.fish
@@ -1,5 +1,12 @@
 function chain.compile -d 'Compiles the prompt'
   set -l IFS ''
+
+  set -q chain_link_open_glyph
+    or set chain_link_open_glyph "<"
+
+  set -q chain_link_close_glyph
+    or set chain_link_close_glyph ">"
+
   begin
     echo 'function __chain_compiled_prompt'
     echo 'set -l IFS "\n"'
@@ -15,7 +22,7 @@ function chain.compile -d 'Compiles the prompt'
             and echo -n '-'
             or set next
 
-          builtin printf '<%s>' \"\$segment[2]\"
+          builtin printf '$chain_link_open_glyph%s$chain_link_close_glyph' \"\$segment[2]\"
         end
       "
     end


### PR DESCRIPTION
This fixes #4 by allowing to customize the bracket character using the environment variables `chain_link_open_glyph` and `chain_link_close_glyph`. They default to `<` and `>`, keeping the appearance as it is unless explicitly customized.