### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/chain.compile.fish
+++ b/functions/chain.compile.fish
@@ -16,7 +16,7 @@ function chain.compile -d 'Compiles the prompt'
         set -l segment ($command)
 
         if set -q segment[2]
-          builtin set_color \$segment[1] ^ /dev/null
+          builtin set_color \$segment[1] 2> /dev/null
 
           set -q next
             and echo -n '-'
@@ -27,7 +27,7 @@ function chain.compile -d 'Compiles the prompt'
       "
     end
 
-    echo 'builtin set_color normal ^ /dev/null'
+    echo 'builtin set_color normal 2> /dev/null'
     echo 'end'
   end | source
 end

--- a/functions/chain.inspect.fish
+++ b/functions/chain.inspect.fish
@@ -1,8 +1,8 @@
 function chain.inspect -d 'Inspect your active prompt links'
   if not functions -q __chain_compiled_prompt
-    builtin set_color red ^ /dev/null
+    builtin set_color red 2> /dev/null
     echo "Prompt is not compiled!"
-    builtin set_color normal ^ /dev/null
+    builtin set_color normal 2> /dev/null
     echo
   end
 
@@ -13,23 +13,23 @@ function chain.inspect -d 'Inspect your active prompt links'
     set -l command_status $status
 
     if test $command_status -gt 0
-      builtin set_color red ^ /dev/null
+      builtin set_color red 2> /dev/null
       echo "  $command (exit code $command_status)"
-      builtin set_color normal ^ /dev/null
+      builtin set_color normal 2> /dev/null
     else
-      builtin set_color blue ^ /dev/null
+      builtin set_color blue 2> /dev/null
       echo "  $command"
-      builtin set_color normal ^ /dev/null
+      builtin set_color normal 2> /dev/null
     end
 
     if set -q segment[2]
-      builtin set_color $segment[1] ^ /dev/null
+      builtin set_color $segment[1] 2> /dev/null
       builtin printf '    <%s>\n' "$segment[2]"
-      builtin set_color normal ^ /dev/null
+      builtin set_color normal 2> /dev/null
     else
-      builtin set_color $fish_color_autosuggestion ^ /dev/null
+      builtin set_color $fish_color_autosuggestion 2> /dev/null
       echo '    (no output)'
-      builtin set_color normal ^ /dev/null
+      builtin set_color normal 2> /dev/null
     end
   end
 

--- a/functions/chain.links.jobs.fish
+++ b/functions/chain.links.jobs.fish
@@ -1,6 +1,6 @@
 function chain.links.jobs
   # Check if there are any jobs running.
-  if jobs -l > /dev/null ^&1
+  if jobs -l > /dev/null 2>&1
     set -l job_count (jobs -l | cut -f1)
 
     echo white

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -23,13 +23,13 @@ function fish_prompt
 
   # Prompt arrow with status of last command.
   if test $__chain_last_status = 0
-    builtin set_color green ^ /dev/null
+    builtin set_color green 2> /dev/null
   else
-    builtin set_color $fish_color_error ^ /dev/null
+    builtin set_color $fish_color_error 2> /dev/null
     echo -n "$__chain_last_status-"
   end
 
   echo -n "$chain_prompt_glyph "
 
-  builtin set_color normal ^ /dev/null
+  builtin set_color normal 2> /dev/null
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618