### PR TITLE
Added chain.insert to add an item to chain at a specific index

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Remove the first link in the prompt chain.
 ### `chain.unshift <function>`
 Add a _link function_ to the beginning of the prompt chain.
 
+### `chain.insert <function> <position>`
+Insert a _link function_ in front of the given position.
 
 ## Customization
 Chain uses several global variables to customize the prompt appearance. The most important one is `$chain_links`: a list of function names that print out a single link in the prompt.

--- a/functions/chain.insert.fish
+++ b/functions/chain.insert.fish
@@ -1,0 +1,33 @@
+function chain.insert -a command position -d 'Adds a link to your prompt chain at given position'
+
+    if test -z $position
+        echo "Position argument is required"
+        return 1
+    end
+
+    if not string match -qr '^-?\d+$' $position
+        echo "Position not an integer"
+        return 1
+    end
+
+    set -l current_length (count $chain_links)
+    if test $position -lt 0 -o $position -gt $current_length
+        echo "Invalid position"
+        return 1
+    end
+
+    if test $position -eq $current_length
+        set -U chain_links $chain_links "$command"
+    else if test $position -eq 0
+        set -U chain_links "$command" $chain_links
+    else
+        set -l before_slice $chain_links[1..$position]
+        set -l after_slice $chain_links[(math $position + 1)..-1]
+        set -U chain_links $before_slice "$command" $after_slice
+    end
+
+    # If the user runs this command, recompile the prompt for them so that their changes are immediately visible.
+    if test "$_" = chain.insert
+        chain.compile
+    end
+end


### PR DESCRIPTION
Allows for the ability to add a function in front of a specific index.

example:

if $chain_links currently has

`chain.links.root chain.links.jobs chain.links.pwd chain.links.vcs_branch chain.links.vcs_dirty chain.links.vcs_stashed`

```fish
chain.insert example 2
```

will add the function `example` in front of chain.links.jobs modifying chain_links to look like this:

`chain.links.root chain.links.jobs example chain.links.pwd chain.links.vcs_branch chain.links.vcs_dirty chain.links.vcs_stashed`

