### PR TITLE
Added chain.save chain.custom to save

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Remove the first link in the prompt chain.
 ### `chain.unshift <function>`
 Add a _link function_ to the beginning of the prompt chain.
 
+### `chain.save`
+Saves the current chain prompt configuration
+
+### `chain.custom`
+Sets the chain prompt to your saved configuration
 
 ## Customization
 Chain uses several global variables to customize the prompt appearance. The most important one is `$chain_links`: a list of function names that print out a single link in the prompt.

--- a/functions/chain.custom.fish
+++ b/functions/chain.custom.fish
@@ -1,3 +1,7 @@
 function chain.custom -d 'Sets chain to saved custom chain'
     set -U chain_links $custom_chain
+
+    if test "$_" = chain.custom
+        chain.compile
+    end
 end

--- a/functions/chain.custom.fish
+++ b/functions/chain.custom.fish
@@ -1,0 +1,3 @@
+function chain.custom -d 'Sets chain to saved custom chain'
+    set -U chain_links $custom_chain
+end

--- a/functions/chain.save.fish
+++ b/functions/chain.save.fish
@@ -1,0 +1,3 @@
+function chain.save -d 'Saves current custom chain'
+    set -U custom_chain $chain_links
+end


### PR DESCRIPTION
Allows the functionality to save your current prompt with
`chain.save`
and set it with
`chain.custom`
Allowing the ability to roll back to a desired prompt setting after changes